### PR TITLE
MJ3 - Modifying send button request payload to send accurate (non-placeholder) information about scribble to server and database

### DIFF
--- a/public/js/canvas.js
+++ b/public/js/canvas.js
@@ -187,10 +187,6 @@ function sendMessage(event)
 
     const data = {
         image: imageLink.href,
-        chatroom: 'myChatroom',
-        author_name: 'John Doe',
-        latitude: 42.1234,
-        longitude: -71.5678,
     };
 
     fetch('/sendMessage', {
@@ -201,7 +197,7 @@ function sendMessage(event)
         .then(res => res.json())
         .then(data =>
         {
-            console.log(data.scribble);
+            console.log("Successfully sent scribble to server.");
         })
         .catch(err => console.error(err));
 }

--- a/routes/chatroom.js
+++ b/routes/chatroom.js
@@ -20,9 +20,12 @@ router.get("/", (req, res) => {
 })
 
 router.post('/sendMessage', (req, res) => {
-    const { image, chatroom, author_name, latitude, longitude } = req.body;
-    
-    console.log(image, chatroom, author_name, latitude, longitude);
+    const image = req.body.image;
+    const chatroom = req.session.serverName;
+    const author_name = req.session.username;
+    const latitude = 42.1234;  // placeholder
+    const longitude = -71.5678;  // placeholder
+  
     try {
       const scribble = new Scribble({
         image,
@@ -33,8 +36,9 @@ router.post('/sendMessage', (req, res) => {
       });
 
       scribble.save();
-      
-      res.status(201).json({ success: true, scribble });
+      const successMessage = `Successfully saved scribble to database from author ${author_name} in the ${chatroom} chatroom.`;
+      res.status(201).json({ success: true, message: successMessage});
+      console.log(successMessage);
     } catch (err) {
       console.error(err);
       res.status(500).json({ success: false, message: 'Failed to create scribble.' });


### PR DESCRIPTION
This is branched off of the previous chatroom server name fix branch. This allows the send button to send the scribble information to the database (with the exception of the location information due to a soon-to-end lack of implementation).

Here's an example:

![image](https://user-images.githubusercontent.com/78712025/227626142-7b94deb0-fcd7-4aa7-b6e9-4c8af4abfd40.png)
![image](https://user-images.githubusercontent.com/78712025/227626132-47d64a18-393f-4cb8-b0d9-f4b41e904a9d.png)
![image](https://user-images.githubusercontent.com/78712025/227626277-cafb2291-2d3e-4da9-8212-7a790917c0a0.png)

When I hit the send button after drawing, it stores the information appropriately in the database and logs a success message.